### PR TITLE
Update parseUserAgentString.php

### DIFF
--- a/parseUserAgentString.php
+++ b/parseUserAgentString.php
@@ -74,6 +74,16 @@ class parseUserAgentStringClass {
 	public $deviceTypePC = "PC";
 	public $deviceTypeScript = "script";
 
+	public $type = "";
+	public $android = "";
+	public $androidVersion = "";
+	public $processOperatingSystemString = "";
+	public $windows = "";
+	public $windowsNTVersion = "";
+	public $macosxv = "";
+	public $ios = "";
+	public $iosVersion = "";
+	
 	function StringContains($haystack, $needle) {
 		if (stristr($haystack, $needle) === FALSE) return false;
 		else return true;


### PR DESCRIPTION
After my PHP 8.2 upgrade I downloaded this v1.38 and get a series of errors. After first finding a few missing declarations, I checked them all. These are all the declarations that were missing. They all threw up PHP errors. This fixed it for me.